### PR TITLE
Feature/bad request handler

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/config/MessagesConfig.java
+++ b/src/main/java/com/softserveinc/dokazovi/config/MessagesConfig.java
@@ -1,0 +1,26 @@
+package com.softserveinc.dokazovi.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Configuration
+public class MessagesConfig {
+
+	@Bean
+	public MessageSource messageSource() {
+		ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+		messageSource.setBasename("classpath:messages");
+		messageSource.setDefaultEncoding("UTF-8");
+		return messageSource;
+	}
+
+	@Bean
+	public LocalValidatorFactoryBean getValidator() {
+		LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+		bean.setValidationMessageSource(messageSource());
+		return bean;
+	}
+}

--- a/src/main/java/com/softserveinc/dokazovi/controller/AuthController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.softserveinc.dokazovi.service.ProviderService;
 import com.softserveinc.dokazovi.service.UserService;
 import com.softserveinc.dokazovi.util.MailSenderUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -28,6 +29,7 @@ import javax.mail.MessagingException;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Locale;
 
 import static com.softserveinc.dokazovi.controller.EndPoints.AUTH;
 import static com.softserveinc.dokazovi.controller.EndPoints.AUTH_LOGIN;
@@ -45,6 +47,9 @@ public class AuthController {
 	private final MailSenderUtil mailSenderUtil;
 	private final UserService userService;
 	private final ProviderService providerService;
+	private final MessageSource messageSource;
+
+	private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
 	@PostMapping(AUTH_LOGIN)
 	public ResponseEntity<AuthResponse> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
@@ -58,7 +63,8 @@ public class AuthController {
 		String token = tokenProvider.createToken(authentication);
 		UserEntity userEntity = userService.findByEmail(loginRequest.getEmail());
 		if (!userEntity.getEnabled()) {
-			throw new BadRequestException("Please confirm your email!");
+			String errorMessage = messageSource.getMessage("email.notconfirmed", null, DEFAULT_LOCALE);
+			throw new BadRequestException(errorMessage);
 		} else {
 			AuthResponse authResponse = new AuthResponse(token);
 			authResponse.setAccessToken(token);
@@ -70,7 +76,8 @@ public class AuthController {
 	public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody SignUpRequest signUpRequest)
 			throws IOException, MessagingException {
 		if (providerService.existsByLocalEmail(signUpRequest.getEmail())) {
-			throw new BadRequestException("Email address already in use.");
+			String errorMessage = messageSource.getMessage("email.notunique", null, DEFAULT_LOCALE);
+			throw new BadRequestException(errorMessage);
 		}
 		UserEntity user = userService.registerNewUser(signUpRequest);
 		providerService.createLocalProviderEntityForUser(user, signUpRequest.getEmail());

--- a/src/main/java/com/softserveinc/dokazovi/exception/handler/CustomRestExceptionHandler.java
+++ b/src/main/java/com/softserveinc/dokazovi/exception/handler/CustomRestExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.softserveinc.dokazovi.exception.handler;
 
+import com.softserveinc.dokazovi.exception.BadRequestException;
 import com.softserveinc.dokazovi.exception.DtoException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -7,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -44,5 +47,16 @@ public class CustomRestExceptionHandler extends ResponseEntityExceptionHandler {
 				.errors(Collections.singletonList(ex.getLocalizedMessage()))
 				.build();
 		return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
+	}
+
+	@ExceptionHandler({BadRequestException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ResponseBody
+	public ApiError handleBadRequestException(final BadRequestException ex) {
+		logger.info(ex.getClass().getName() + ": " + ex.getLocalizedMessage());
+		return ApiError.builder()
+				.status(HttpStatus.BAD_REQUEST)
+				.errors(Collections.singletonList(ex.getLocalizedMessage()))
+				.build();
 	}
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,2 @@
+email.notunique = Email address already in use.
+email.notconfirmed = Please confirm your email!

--- a/src/test/java/com/softserveinc/dokazovi/controller/AuthControllerTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.context.MessageSource;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -64,6 +66,8 @@ class AuthControllerTest {
     private ProviderService providerService;
     @Mock
     private UserService userService;
+    @Mock
+    private MessageSource messageSource;
     @InjectMocks
     private AuthController authController;
 
@@ -164,11 +168,13 @@ class AuthControllerTest {
     @Test
     void shouldRejectRegistrationWithNotUniqueEmailTest() throws Exception {
         String uri = AUTH + AUTH_SIGNUP;
+        String errorMessage = "Email address already in use.";
         SignUpRequest request = new SignUpRequest();
         request.setEmail("user@mail.com");
         request.setName("name");
         request.setPassword("password");
         when(providerService.existsByLocalEmail(anyString())).thenReturn(true);
+        when(messageSource.getMessage(eq("email.notunique"), any(), any())).thenReturn(errorMessage);
 
         mockMvc.perform(
                 post(uri)
@@ -176,12 +182,13 @@ class AuthControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(result -> assertTrue(result.getResolvedException() instanceof BadRequestException))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().string((containsString("Email address already in use."))));
+                .andExpect(content().string((containsString(errorMessage))));
     }
 
     @Test
     void shouldRejectLoginWithUnconfirmedEmailTest() throws Exception {
         String uri = AUTH + AUTH_LOGIN;
+        String errorMessage = "Please confirm your email!";
         LoginRequest request = new LoginRequest();
         request.setEmail("user@mail.com");
         request.setPassword("password");
@@ -189,6 +196,7 @@ class AuthControllerTest {
                 .enabled(false)
                 .build();
         when(userService.findByEmail(anyString())).thenReturn(user);
+        when(messageSource.getMessage(eq("email.notconfirmed"), any(), any())).thenReturn(errorMessage);
 
         mockMvc.perform(
                 post(uri)
@@ -196,7 +204,7 @@ class AuthControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(result -> assertTrue(result.getResolvedException() instanceof BadRequestException))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().string((containsString("Please confirm your email!"))));
+                .andExpect(content().string((containsString(errorMessage))));
     }
 
     public static String asJsonString(final Object obj) {


### PR DESCRIPTION
## Summary of issue

The CustomRestExceptionHandler class didn't handle "Bad Request" exceptions. 
Therefore, for the server didn't include a descriptive error message (for example "Email address already in use" or "Please confirm your email") in a response body of "400 Bad Request" response.


## Summary of change

- added a method to the CustomRestExceptionHandler class in order to handle a BadRequestException
- moved string values of descriptive error messages for Bad Request exceptions to a file messages.properties
