### PR TITLE
Trim the "bio" field in the experts entity

### DIFF
--- a/src/main/resources/db/testdata/V1.5__trim_bio_field_in_doctors_table.sql
+++ b/src/main/resources/db/testdata/V1.5__trim_bio_field_in_doctors_table.sql
@@ -1,0 +1,4 @@
+UPDATE DOCTORS SET BIO='Lorem ipsum dolor sit amet, consectetur adipiscing' WHERE DOCTOR_ID>=1 AND DOCTOR_ID<=9;
+UPDATE DOCTORS SET BIO='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a.' WHERE DOCTOR_ID>=10 AND DOCTOR_ID<=18;
+UPDATE DOCTORS SET BIO='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam q.' WHERE DOCTOR_ID>=19 AND DOCTOR_ID<=27;
+UPDATE DOCTORS SET BIO='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis.' WHERE DOCTOR_ID>=28 AND DOCTOR_ID<=36;


### PR DESCRIPTION
**Issue link**

[#318 Trim the "bio" field in the experts entity](https://github.com/ita-social-projects/dokazovi-be/issues/318 )


## Code reviewers
- [x] @alexandr-bielan 

## Summary of issue

- [x]  Add sql script to trim bio in strings with 50/100/150/200 symbols

## Summary of change

- [x]  Added sql script
