### PR TITLE
Fixed GOOGLE_CREDENTIALS variable check in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.servlet.context-path=/api
 server.port=${PORT:8080}
 endpoints.cors=${ALLOWED_ORIGIN: http://localhost:3000, https://dokazovi-fe.herokuapp.com, http://127.0.0.1:3000,\
                                  http://127.0.0.2:3000, https://dokazovi-frontend.herokuapp.com}
-analytics.creds=${GOOGLE_CREDENTIALS}
+analytics.creds=${GOOGLE_CREDENTIALS:noop}
 
 #-------------------------
 # Database PostgresSQL

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 info.build.version=${BUILD_VERSION:0.0.0}
 endpoints.cors=${ALLOWED_ORIGIN: http://localhost:3000, https://dokazovi-fe.herokuapp.com}
-analytics.creds=${GOOGLE_CREDENTIALS}
+analytics.creds=${GOOGLE_CREDENTIALS:noop}
 
 #-------------------------
 # Database H2


### PR DESCRIPTION
develop

## GitHub Board

[#395 The application requires GOOGLE_CREDENTIALS environment variable to be set](https://github.com/ita-social-projects/dokazovi-be/issues/395)


## Code reviewers
I am new to this project, and not even an intern yet, so I do not know whom to ping here.

## Summary of issue

`GOOGLE_CREDENTIALS` was not defaulting to `noop` in `application.properties`, even though that was intended in `GoogleAnalytics` class.

## Summary of change

Made it default to `noop`.

This change is sent directly to the `develop` branch, as it seems to be too small to actually break anything, and unit tests were run.
Feel free to redirect this to another branch if you think it is a better idea here.