### PR TITLE
Update endpoints for expert posts and post types by status

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
@@ -201,7 +201,7 @@ public class PostController {
 	 *
 	 * @param pageable interface for pagination information
 	 * @param expert   expert id
-	 * @param type     post type id
+	 * @param types    the type's ids by which the search is performed
 	 * @return page with found posts and HttpStatus 'OK'
 	 */
 	@GetMapping(POST_LATEST_BY_EXPERT_AND_STATUS)
@@ -211,13 +211,13 @@ public class PostController {
 			@PageableDefault Pageable pageable,
 			@ApiParam(value = "Expert's id")
 			@RequestParam Integer expert,
-			@ApiParam(value = "Post type id")
-			@RequestParam(required = false) Set<Integer> type,
+			@ApiParam(value = "Multiple comma-separated post types IDs, e.g. ?types=1,2,3,4", type = "string")
+			@RequestParam(required = false) Set<Integer> types,
 			@ApiParam(value = "Status")
 			@RequestParam PostStatus status) {
 		return ResponseEntity
 				.status(HttpStatus.OK)
-				.body(postService.findAllByExpertAndTypeAndStatus(expert, type, status, pageable));
+				.body(postService.findAllByExpertAndTypeAndStatus(expert, types, status, pageable));
 	}
 
 	/**

--- a/src/main/java/com/softserveinc/dokazovi/controller/PostTypesController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostTypesController.java
@@ -1,14 +1,17 @@
 package com.softserveinc.dokazovi.controller;
 
 import com.softserveinc.dokazovi.dto.post.PostTypeDTO;
+import com.softserveinc.dokazovi.entity.enumerations.PostStatus;
 import com.softserveinc.dokazovi.service.PostTypeService;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -34,9 +37,12 @@ public class PostTypesController {
 	 */
 	@GetMapping(POST_TYPES_ALL_TYPES_BY_USER)
 	@ApiOperation(value = "Get all types of materials by userId")
-	public ResponseEntity<List<PostTypeDTO>> getAllPostTypesByUserId(@PathVariable("userId") Integer userId) {
+	public ResponseEntity<List<PostTypeDTO>> getAllPostTypesByUserId(
+			@PathVariable("userId") Integer userId,
+			@ApiParam(value = "Status")
+			@RequestParam(required = false) PostStatus status) {
 		return ResponseEntity
 				.status(HttpStatus.OK)
-				.body(postTypeService.findAllPostTypesByUserId(userId));
+				.body(postTypeService.findAllPostTypesByUserIdAndStatus(userId, status));
 	}
 }

--- a/src/main/java/com/softserveinc/dokazovi/repositories/PostTypeRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/PostTypeRepository.java
@@ -1,6 +1,7 @@
 package com.softserveinc.dokazovi.repositories;
 
 import com.softserveinc.dokazovi.entity.PostTypeEntity;
+import com.softserveinc.dokazovi.entity.enumerations.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -17,4 +18,13 @@ public interface PostTypeRepository extends JpaRepository<PostTypeEntity, Intege
 					+ "                   FROM POSTS P "
 					+ "                   WHERE P.AUTHOR_ID IN (:userId))) ")
 	List<PostTypeEntity> findAllPostTypesByUserId(Integer userId);
+
+	@Query(nativeQuery = true,
+			value = " SELECT * "
+					+ " FROM POST_TYPES"
+					+ " WHERE TYPE_ID IN (SELECT DISTINCT P.TYPE_ID "
+					+ "                   FROM POSTS P "
+					+ "                   WHERE P.AUTHOR_ID = :userId "
+					+ "                     AND P.status = :#{#postStatus?.name()}) ")
+	List<PostTypeEntity> findAllPostTypesByUserIdAndStatus(Integer userId, PostStatus postStatus);
 }

--- a/src/main/java/com/softserveinc/dokazovi/service/PostTypeService.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/PostTypeService.java
@@ -1,6 +1,7 @@
 package com.softserveinc.dokazovi.service;
 
 import com.softserveinc.dokazovi.dto.post.PostTypeDTO;
+import com.softserveinc.dokazovi.entity.enumerations.PostStatus;
 
 import java.util.List;
 
@@ -9,4 +10,6 @@ public interface PostTypeService {
 	List<PostTypeDTO> findAll();
 
 	List<PostTypeDTO> findAllPostTypesByUserId(Integer userId);
+
+	List<PostTypeDTO> findAllPostTypesByUserIdAndStatus(Integer userId, PostStatus postStatus);
 }

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostTypeServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostTypeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.softserveinc.dokazovi.service.impl;
 
 import com.softserveinc.dokazovi.dto.post.PostTypeDTO;
+import com.softserveinc.dokazovi.entity.enumerations.PostStatus;
 import com.softserveinc.dokazovi.mapper.PostTypeMapper;
 import com.softserveinc.dokazovi.repositories.PostTypeRepository;
 import com.softserveinc.dokazovi.service.PostTypeService;
@@ -28,6 +29,17 @@ public class PostTypeServiceImpl implements PostTypeService {
 	@Override
 	public List<PostTypeDTO> findAllPostTypesByUserId(Integer userId) {
 		return postTypeRepository.findAllPostTypesByUserId(userId)
+				.stream()
+				.map(postTypeMapper::toPostTypeDTO)
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	public List<PostTypeDTO> findAllPostTypesByUserIdAndStatus(Integer userId, PostStatus postStatus) {
+		if (postStatus == null) {
+			return findAllPostTypesByUserId(userId);
+		}
+		return postTypeRepository.findAllPostTypesByUserIdAndStatus(userId, postStatus)
 				.stream()
 				.map(postTypeMapper::toPostTypeDTO)
 				.collect(Collectors.toList());

--- a/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
@@ -227,7 +227,7 @@ class PostControllerTest {
 		PostStatus postStatus = PostStatus.DRAFT;
 		Pageable pageable = PageRequest.of(0, 10);
 		mockMvc.perform(
-				get(POST + POST_LATEST_BY_EXPERT_AND_STATUS + "?expert=2&type=1,2&status=DRAFT"))
+				get(POST + POST_LATEST_BY_EXPERT_AND_STATUS + "?expert=2&types=1,2&status=DRAFT"))
 				.andExpect(status().isOk());
 		verify(postService).findAllByExpertAndTypeAndStatus(expertId, typeId, postStatus, pageable);
 	}

--- a/src/test/java/com/softserveinc/dokazovi/controller/PostTypesControllerTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/controller/PostTypesControllerTest.java
@@ -1,5 +1,6 @@
 package com.softserveinc.dokazovi.controller;
 
+import com.softserveinc.dokazovi.entity.enumerations.PostStatus;
 import com.softserveinc.dokazovi.service.PostTypeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,12 @@ public class PostTypesControllerTest {
 	@Test
 	void getAllPostTypesByUserId() throws Exception {
 		mockMvc.perform(get(POST_TYPES + "/1")).andExpect(status().isOk());
-		verify(postTypeService).findAllPostTypesByUserId(1);
+		verify(postTypeService).findAllPostTypesByUserIdAndStatus(1, null);
+	}
+
+	@Test
+	void getAllPostTypesByUserId_WhenStatusIsPresent_IsOk() throws Exception {
+		mockMvc.perform(get(POST_TYPES + "/1?status=DRAFT")).andExpect(status().isOk());
+		verify(postTypeService).findAllPostTypesByUserIdAndStatus(1, PostStatus.DRAFT);
 	}
 }

--- a/src/test/java/com/softserveinc/dokazovi/service/impl/PostTypeServiceImplTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/service/impl/PostTypeServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.softserveinc.dokazovi.service.impl;
 
 import com.softserveinc.dokazovi.entity.PostTypeEntity;
+import com.softserveinc.dokazovi.entity.enumerations.PostStatus;
 import com.softserveinc.dokazovi.mapper.PostTypeMapper;
 import com.softserveinc.dokazovi.repositories.PostTypeRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,20 @@ class PostTypeServiceImplTest {
 	void findAllPostTypesByUserId() {
 		when(postTypeRepository.findAllPostTypesByUserId(2)).thenReturn(postTypeEntities);
 		postTypeService.findAllPostTypesByUserId(2);
+		verify(postTypeMapper, times(postTypeEntities.size())).toPostTypeDTO(any(PostTypeEntity.class));
+	}
+
+	@Test
+	void findAllPostTypesByUserIdAndStatus_WhenStatusIsPresent_IsOk() {
+		when(postTypeRepository.findAllPostTypesByUserIdAndStatus(2, PostStatus.DRAFT)).thenReturn(postTypeEntities);
+		postTypeService.findAllPostTypesByUserIdAndStatus(2, PostStatus.DRAFT);
+		verify(postTypeMapper, times(postTypeEntities.size())).toPostTypeDTO(any(PostTypeEntity.class));
+	}
+
+	@Test
+	void findAllPostTypesByUserIdAndStatus_WhenStatusIsEmpty_IsOk() {
+		when(postTypeRepository.findAllPostTypesByUserId(2)).thenReturn(postTypeEntities);
+		postTypeService.findAllPostTypesByUserIdAndStatus(2, null);
 		verify(postTypeMapper, times(postTypeEntities.size())).toPostTypeDTO(any(PostTypeEntity.class));
 	}
 }


### PR DESCRIPTION
## GitHub Board

**Issue link**

[#406 Update endpoint for getting the expert post types by status](https://github.com/ita-social-projects/dokazovi-be/issues/406)
[#407 Fix endpoint for getting the expert posts by status](https://github.com/ita-social-projects/dokazovi-be/issues/407)

**Story link**

[#83 Review published materials](https://github.com/ita-social-projects/dokazovi-requirements/issues/83)

## Code reviewers
- [ ] @teaFunny 

## Summary of issue

 - [ ] Update api endpoint controller for getting post types (add optional parameter 'status')
 - [ ] Update api endpoint controller for getting posts.
 - [ ] Update service for getting post types.
 - [ ] Update repository for getting post types.
 - [ ] Update tests

## Summary of change

 - [ ] Updated api endpoint controller for getting post types (add optional parameter 'status')
 - [ ] Updated api endpoint controller for getting posts.
 - [ ] Updated service for getting post types.
 - [ ] Updated repository for getting post types.
 - [ ] Updated tests