### PR TITLE
Issue 430 fix getting posts by important image

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/repositories/PostRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/PostRepository.java
@@ -173,7 +173,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
 					+ "           ELSE P1.POST_ID IS NOT NULL "
 					+ "      END "
 					+ "ORDER BY (P1.IMPORTANT_IMAGE_URL <> '' AND P1.IMPORTANT_IMAGE_URL IS NOT NULL) DESC, "
-					+ "          P1.CREATED_AT DESC "
+					+ "          P1.CREATED_AT DESC, P1.POST_ID "
 	)
 	Page<PostEntity> findByDirectionsAndTypesAndOriginsAndStatusAndImportantSortedByImportantImagePresence(
 			Set<Integer> directionsIds, Set<Integer> typesIds, Set<Integer> originsIds, PostStatus postStatus,

--- a/src/main/java/com/softserveinc/dokazovi/repositories/PostRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/PostRepository.java
@@ -148,14 +148,6 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
 
 	@Query(nativeQuery = true,
 			value = "SELECT P1.* FROM POSTS P1 "
-					+ " WHERE P1.STATUS = 'PUBLISHED' "
-					+ " AND P1.IMPORTANT = FALSE"
-					+ " ORDER BY (P1.IMPORTANT_IMAGE_URL <> '' AND P1.IMPORTANT_IMAGE_URL IS NOT NULL) DESC, "
-					+ " P1.CREATED_AT DESC ")
-	Page<PostEntity> findAllByImportantImageUrlDesc (Pageable pageable);
-
-	@Query(nativeQuery = true,
-			value = "SELECT P1.* FROM POSTS P1 "
 					+ "WHERE P1.STATUS = :#{#postStatus.name()} "
 					+ "  AND P1.IMPORTANT = :important "
 					+ "  AND CASE WHEN :typesIds IS NOT NULL "
@@ -173,7 +165,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
 					+ "           ELSE P1.POST_ID IS NOT NULL "
 					+ "      END "
 					+ "ORDER BY (P1.IMPORTANT_IMAGE_URL <> '' AND P1.IMPORTANT_IMAGE_URL IS NOT NULL) DESC, "
-					+ "          P1.CREATED_AT DESC, P1.POST_ID "
+					+ "          P1.PUBLISHED_AT DESC, P1.POST_ID "
 	)
 	Page<PostEntity> findByDirectionsAndTypesAndOriginsAndStatusAndImportantSortedByImportantImagePresence(
 			Set<Integer> directionsIds, Set<Integer> typesIds, Set<Integer> originsIds, PostStatus postStatus,

--- a/src/main/java/com/softserveinc/dokazovi/service/PostService.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/PostService.java
@@ -45,8 +45,6 @@ public interface PostService {
 
 	Integer getPostViewCount(String url);
 
-	Page<PostDTO> getAllByImportantImageUrl(Pageable pageable);
-
 	Page<PostDTO> findPublishedNotImportantPostsWithFiltersSortedByImportantImagePresence(
 			Set<Integer> directionIds, Set<Integer> typeIds, Set<Integer> originIds, Pageable pageable);
 }

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
@@ -319,11 +319,6 @@ public class PostServiceImpl implements PostService {
 	}
 
 	@Override
-	public Page<PostDTO> getAllByImportantImageUrl(Pageable pageable) {
-		return postRepository.findAllByImportantImageUrlDesc(pageable).map(postMapper::toPostDTO);
-	}
-
-	@Override
 	public Page<PostDTO> findPublishedNotImportantPostsWithFiltersSortedByImportantImagePresence(
 			Set<Integer> directions, Set<Integer> types, Set<Integer> origins, Pageable pageable) {
 		return postRepository.findByDirectionsAndTypesAndOriginsAndStatusAndImportantSortedByImportantImagePresence(


### PR DESCRIPTION
## GitHub Board

**Issue link**
[#430 Fix getting posts by important image](https://github.com/ita-social-projects/dokazovi-be/issues/430)

**Story link**
[#288 As a user with administrator role, I want to see materials in the opened accordion section to add it to the carousel.](https://github.com/ita-social-projects/dokazovi-be/issues/288)

## Code reviewers
- [ ] @Izarx 

## Summary of issue
- [ ]  Update repository

## Summary of change
- [ ]  Updated repository
