### PR TITLE
[Experimentation] Added very basic functionality related to foreign experts

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/config/WebSecurityConfig.java
+++ b/src/main/java/com/softserveinc/dokazovi/config/WebSecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static com.softserveinc.dokazovi.controller.EndPoints.DIRECTION;
+import static com.softserveinc.dokazovi.controller.EndPoints.FOREIGN_EXPERT;
 import static com.softserveinc.dokazovi.controller.EndPoints.ORIGIN;
 import static com.softserveinc.dokazovi.controller.EndPoints.PLATFORM_INFORMATION;
 import static com.softserveinc.dokazovi.controller.EndPoints.POST;
@@ -117,7 +118,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 						"/auth/**", "/oauth2/**")
 					.permitAll()
 				.antMatchers(openApi(USER), openApi(POST), openApi(TAG), openApi(DIRECTION), openApi(REGION),
-							 openApi(VERSION), openApi(POST_TYPES), openApi(ORIGIN), openApi(PLATFORM_INFORMATION))
+							 openApi(VERSION), openApi(POST_TYPES), openApi(ORIGIN), openApi(PLATFORM_INFORMATION), openApi(FOREIGN_EXPERT))
 					.permitAll()
 				.anyRequest()
 					.authenticated()

--- a/src/main/java/com/softserveinc/dokazovi/controller/EndPoints.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/EndPoints.java
@@ -47,6 +47,8 @@ public final class EndPoints {
 	public static final String PLATFORM_INFORMATION = "/platform-information";
 	public static final String PLATFORM_INFORMATION_BY_ID = "/{infoId}";
 	public static final String POST_GET_BY_IMPORTANT_IMAGE = "/get-by-important-image";
+	public static final String FOREIGN_EXPERT = "/foreign-expert";
+	public static final String FOREIGN_EXPERT_SEARCH = "/search";
 
 	/**
 	 * Method that adds slash after each endpoint while calling

--- a/src/main/java/com/softserveinc/dokazovi/controller/ForeignExpertController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/ForeignExpertController.java
@@ -1,0 +1,73 @@
+package com.softserveinc.dokazovi.controller;
+
+import com.softserveinc.dokazovi.annotations.ApiPageable;
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertDTO;
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertSearchResultDTO;
+import com.softserveinc.dokazovi.security.UserPrincipal;
+import com.softserveinc.dokazovi.service.ForeignExpertService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping(EndPoints.FOREIGN_EXPERT)
+@RequiredArgsConstructor
+public class ForeignExpertController {
+	private final ForeignExpertService foreignExpertService;
+
+	/**
+	 * Saves (creates) a foreign expert entry.
+	 *
+	 * <p>Checks if user has authority to perform the request</p>
+	 * @param saveDTO       DTO of the foreign expert
+	 * @param userPrincipal authorized user data
+	 *
+	 * @return HttpStatus 'CREATED' and saves the foreign expert entry to the DB
+	 */
+	@PostMapping
+	@PreAuthorize("hasAuthority('SAVE_FOREIGN_EXPERT')")
+	@ApiOperation(value = "Save a foreign expert", authorizations = {@Authorization(value = "Authorization")})
+	@ApiResponses(value = {
+			@ApiResponse(code = 201, message = HttpStatuses.CREATED, response = ForeignExpertDTO.class),
+			@ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST)
+	})
+	public ResponseEntity<ForeignExpertDTO> save(
+			@Valid @RequestBody ForeignExpertSearchResultDTO saveDTO,
+			@AuthenticationPrincipal UserPrincipal userPrincipal
+	) {
+		return ResponseEntity
+				.status(HttpStatus.CREATED)
+				.body(foreignExpertService.save(saveDTO, userPrincipal));
+	}
+
+	@GetMapping(EndPoints.FOREIGN_EXPERT_SEARCH)
+	@ApiOperation(value = "Search for foreign experts")
+	@ApiPageable()
+	public ResponseEntity<Page<ForeignExpertSearchResultDTO>> search(
+			@RequestParam String query,
+			@PageableDefault(sort = {"full_name"}, direction = Sort.Direction.ASC)
+			Pageable pageable
+	) {
+		return ResponseEntity
+				.status(HttpStatus.OK)
+				.body(foreignExpertService.search(query, pageable));
+	}
+}

--- a/src/main/java/com/softserveinc/dokazovi/dto/foreignexpert/ForeignExpertDTO.java
+++ b/src/main/java/com/softserveinc/dokazovi/dto/foreignexpert/ForeignExpertDTO.java
@@ -1,0 +1,16 @@
+package com.softserveinc.dokazovi.dto.foreignexpert;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForeignExpertDTO {
+	private Integer id;
+	private String fullName;
+	private String bio;
+}

--- a/src/main/java/com/softserveinc/dokazovi/dto/foreignexpert/ForeignExpertSaveDTO.java
+++ b/src/main/java/com/softserveinc/dokazovi/dto/foreignexpert/ForeignExpertSaveDTO.java
@@ -1,0 +1,21 @@
+package com.softserveinc.dokazovi.dto.foreignexpert;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForeignExpertSaveDTO {
+	private Integer id;
+
+	@NotBlank(message = "Full name must be present")
+	private String fullName;
+
+	private String bio;
+}

--- a/src/main/java/com/softserveinc/dokazovi/dto/foreignexpert/ForeignExpertSearchResultDTO.java
+++ b/src/main/java/com/softserveinc/dokazovi/dto/foreignexpert/ForeignExpertSearchResultDTO.java
@@ -1,0 +1,16 @@
+package com.softserveinc.dokazovi.dto.foreignexpert;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForeignExpertSearchResultDTO {
+	private Integer id;
+
+	private String fullName;
+}

--- a/src/main/java/com/softserveinc/dokazovi/entity/ForeignExpertEntity.java
+++ b/src/main/java/com/softserveinc/dokazovi/entity/ForeignExpertEntity.java
@@ -1,0 +1,32 @@
+package com.softserveinc.dokazovi.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "foreign_expert_entity")
+@Table(name = "foreign_experts")
+public class ForeignExpertEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "foreign_expert_id")
+	private Integer id;
+
+	@Column(name = "full_name")
+	private String fullName;
+
+	@Column(name = "bio")
+	private String bio;
+}

--- a/src/main/java/com/softserveinc/dokazovi/entity/enumerations/RolePermission.java
+++ b/src/main/java/com/softserveinc/dokazovi/entity/enumerations/RolePermission.java
@@ -12,7 +12,8 @@ public enum RolePermission implements GrantedAuthority {
 	SAVE_PUBLICATION,
 	SET_IMPORTANCE,
 	SAVE_PLATFORM_INFORMATION,
-	UPDATE_PLATFORM_INFORMATION;
+	UPDATE_PLATFORM_INFORMATION,
+	SAVE_FOREIGN_EXPERT;
 
 	@Override
 	public String getAuthority() {

--- a/src/main/java/com/softserveinc/dokazovi/mapper/ForeignExpertMapper.java
+++ b/src/main/java/com/softserveinc/dokazovi/mapper/ForeignExpertMapper.java
@@ -1,0 +1,22 @@
+package com.softserveinc.dokazovi.mapper;
+
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertDTO;
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertSearchResultDTO;
+import com.softserveinc.dokazovi.entity.ForeignExpertEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ForeignExpertMapper {
+	ForeignExpertDTO toForeignExpertDTO(ForeignExpertEntity entity);
+
+	ForeignExpertEntity toForeignExpertEntity(ForeignExpertSearchResultDTO saveDTO);
+
+	ForeignExpertEntity updateForeignExpertEntityFromDTO(
+			ForeignExpertSearchResultDTO saveDTO,
+			@MappingTarget ForeignExpertEntity entity
+	);
+
+	ForeignExpertSearchResultDTO toForeignExpertSearchResultDTO(ForeignExpertEntity entity);
+}

--- a/src/main/java/com/softserveinc/dokazovi/repositories/ForeignExpertRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/ForeignExpertRepository.java
@@ -1,0 +1,18 @@
+package com.softserveinc.dokazovi.repositories;
+
+import com.softserveinc.dokazovi.entity.ForeignExpertEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ForeignExpertRepository extends JpaRepository<ForeignExpertEntity, Integer> {
+	@Query(
+			nativeQuery = true,
+			value = "SELECT e.* FROM FOREIGN_EXPERTS e " +
+					"WHERE e.full_name LIKE :searchQuery || '%'",
+			countQuery = "SELECT count(*) FROM FOREIGN_EXPERTS " +
+					"WHERE full_name LIKE :searchQuery || '%'"
+	)
+	Page<ForeignExpertEntity> searchByFullName(String searchQuery, Pageable pageable);
+}

--- a/src/main/java/com/softserveinc/dokazovi/service/ForeignExpertService.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/ForeignExpertService.java
@@ -1,0 +1,14 @@
+package com.softserveinc.dokazovi.service;
+
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertDTO;
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertSearchResultDTO;
+import com.softserveinc.dokazovi.security.UserPrincipal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ForeignExpertService {
+
+	ForeignExpertDTO save(ForeignExpertSearchResultDTO saveDTO, UserPrincipal userPrincipal);
+
+	Page<ForeignExpertSearchResultDTO> search(String query, Pageable pageable);
+}

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/ForeignExpertServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/ForeignExpertServiceImpl.java
@@ -1,0 +1,62 @@
+package com.softserveinc.dokazovi.service.impl;
+
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertDTO;
+import com.softserveinc.dokazovi.dto.foreignexpert.ForeignExpertSearchResultDTO;
+import com.softserveinc.dokazovi.entity.ForeignExpertEntity;
+import com.softserveinc.dokazovi.exception.EntityNotFoundException;
+import com.softserveinc.dokazovi.exception.ForbiddenPermissionsException;
+import com.softserveinc.dokazovi.mapper.ForeignExpertMapper;
+import com.softserveinc.dokazovi.repositories.ForeignExpertRepository;
+import com.softserveinc.dokazovi.security.UserPrincipal;
+import com.softserveinc.dokazovi.service.ForeignExpertService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ForeignExpertServiceImpl implements ForeignExpertService {
+
+	private static final Logger logger = LoggerFactory.getLogger(ForeignExpertServiceImpl.class);
+
+	private final ForeignExpertRepository foreignExpertRepository;
+	private final ForeignExpertMapper foreignExpertMapper;
+
+	@Override
+	public ForeignExpertDTO save(ForeignExpertSearchResultDTO saveDTO, UserPrincipal userPrincipal) {
+		if (userPrincipal.getAuthorities().stream().noneMatch(a -> a.getAuthority().equals("SAVE_FOREIGN_EXPERT"))) {
+			throw new ForbiddenPermissionsException();
+		}
+
+		ForeignExpertEntity entity = getEntityFromSaveDTO(saveDTO);
+		entity = foreignExpertRepository.save(entity);
+		return foreignExpertMapper.toForeignExpertDTO(entity);
+	}
+
+	@Override
+	public Page<ForeignExpertSearchResultDTO> search(String query, Pageable pageable) {
+		return foreignExpertRepository.searchByFullName(query, pageable)
+				.map(foreignExpertMapper::toForeignExpertSearchResultDTO);
+	}
+
+	private ForeignExpertEntity getEntityFromSaveDTO(ForeignExpertSearchResultDTO saveDTO) {
+		Integer id = saveDTO.getId();
+		ForeignExpertEntity entity;
+		if (id == null) {
+			entity = foreignExpertMapper.toForeignExpertEntity(saveDTO);
+		} else {
+			ForeignExpertEntity byId = foreignExpertRepository.findById(id)
+					.orElseThrow(EntityNotFoundException::new);
+			entity = foreignExpertMapper.updateForeignExpertEntityFromDTO(
+					saveDTO,
+					byId
+			);
+		}
+
+		return entity;
+	}
+
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,1 +1,3 @@
 spring.flyway.locations=classpath:/db/migration,classpath:/db/testdata
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/db/migration/V14__add_foreign_experts_table.sql
+++ b/src/main/resources/db/migration/V14__add_foreign_experts_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE FOREIGN_EXPERTS
+(
+    FOREIGN_EXPERT_ID SERIAL NOT NULL
+        CONSTRAINT FOREIGN_EXPERTS_PKEY
+             PRIMARY KEY,
+
+    FULL_NAME VARCHAR,
+    BIO VARCHAR
+);
+
+-- This index is used to speed up simple `LIKE 'someSearchPrefix%' queries.
+
+CREATE INDEX FOREIGN_EXPERTS_FULL_NAME_LIKE_IDX
+    ON FOREIGN_EXPERTS(FULL_NAME text_pattern_ops);
+
+-- Here we have to add a Ukrainian fts dictionary file to make the index work properly.
+-- Making it work will allow proper full text search.
+-- Yes, Ukrainian fts is not supported out of the box in postgres.
+
+-- CREATE INDEX FOREIGN_EXPERTS_FULL_NAME_FTS_IDX
+--     ON FOREIGN_EXPERTS
+--     USING GIN (to_tsvector('ukrainian', FULL_NAME));

--- a/src/main/resources/db/testdata/V14.1__add_foreign_experts_auth.sql
+++ b/src/main/resources/db/testdata/V14.1__add_foreign_experts_auth.sql
@@ -1,0 +1,2 @@
+INSERT INTO public.role_permission (role_id, permissions)
+VALUES (1, 'SAVE_FOREIGN_EXPERT');

--- a/src/main/resources/db/testdata/V14.2__add_foreign_experts_demo_data.sql
+++ b/src/main/resources/db/testdata/V14.2__add_foreign_experts_demo_data.sql
@@ -1,0 +1,8 @@
+INSERT INTO public.foreign_experts (full_name, bio)
+VALUES ('John Doe', 'Bio #1');
+
+INSERT INTO public.foreign_experts (full_name, bio)
+VALUES ('Zhong Cun', 'Bio #2');
+
+INSERT INTO public.foreign_experts (full_name, bio)
+VALUES ('Foo Bar', 'Bio #3');


### PR DESCRIPTION
Foreign experts are authors of articles translated from foreign languages.

According to what was said and what I understand, we have to have a way to account them, but not as username/password users.

## GitHub Board

**Issue link**

[Support managing foreign experts for translated articles](https://github.com/ita-social-projects/dokazovi-be/issues/435)

**Story link**

Just as the issue says - none yet.

## Code reviewers
- [ ] @StanislavKucher 

## Notes
Please note that this is an experimental draft PR. It's not ready to merge.