### PR TITLE
Fixed broken expert search in admins editor

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
@@ -180,8 +180,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 	 */
 	@Query(nativeQuery = true,
 			value = " SELECT U.* FROM USERS U "
-					+ "     WHERE UPPER(U.FIRST_NAME || ' ' || U.LAST_NAME) LIKE (UPPER(:name) || '%') "
-					+ "        OR UPPER(U.LAST_NAME || ' ' || U.FIRST_NAME) LIKE (UPPER(:name) || '%') "
+					+ "     WHERE UPPER((U.FIRST_NAME || ' ' || U.LAST_NAME) COLLATE \"uk-ua-dokazovi-x-icu\")"
+					+ "         LIKE UPPER((:name || '%') COLLATE \"uk-ua-dokazovi-x-icu\") "
+					+ "        OR UPPER((U.LAST_NAME || ' ' || U.FIRST_NAME) COLLATE \"uk-ua-dokazovi-x-icu\")"
+					+ "         LIKE UPPER((:name || '%') COLLATE \"uk-ua-dokazovi-x-icu\") "
 					+ "   ORDER BY U.FIRST_NAME, U.LAST_NAME ")
 	Page<UserEntity> findDoctorsByName(@Param("name") String name, Pageable pageable);
 

--- a/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
@@ -186,43 +186,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 	Page<UserEntity> findDoctorsByName(@Param("name") String name, Pageable pageable);
 
 	/**
-	 * Gets the page of doctors by firstName and lastName.	 *
-	 * Sorts the experts according to the coincidence. First, the experts with the same firstname and  lastname are
-	 * displayed. Through   the CASE...WHEN...THEN statement, the TURN parameter is defined. Then results of the SELECT
-	 * statement are sorted according to the parameter TURN.
-	 *
-	 * @param firstName received from user service
-	 * @param lastName received from user service
-	 * @param pageable interface for pagination information received from user service
-	 * @return  the resulting user entity page
-	 * @deprecated Please try to not use this method, as it is much heavier than needed, introduces various bugs and is
-	 *             ultimately slow to debug.
-	 */
-	@Deprecated(since = "26.08.2021")
-	@Query(nativeQuery = true,
-			value = "SELECT *, "
-					+ "  CASE "
-					+ "         WHEN ((UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:firstName), '%') "
-					+ "               AND UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:lastName), '%'))) "
-					+ "           OR ((UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:lastName), '%')"
-					+ "               AND UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:firstName), '%')))  THEN 1"
-					+ "         WHEN (UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:lastName), '%')) "
-					+ "           OR (UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:firstName), '%'))"
-					+ "           OR (UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:firstName), '%')) "
-					+ "           OR (UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:lastName), '%'))       THEN 2"
-					+ "                                                               ELSE 3 "
-					+ "     END as TURN "
-					+ "   FROM USERS U "
-					+ "     JOIN DOCTORS D ON U.USER_ID = D.USER_ID "
-					+ "       WHERE (UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:lastName), '%')) "
-					+ "         OR (UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:firstName), '%'))"
-					+ "         OR (UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:lastName), '%'))"
-					+ "         OR (UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:firstName), '%'))"
-					+ "       ORDER BY TURN")
-	Page<UserEntity> findDoctorsByName(
-			@Param("firstName") String firstName, @Param("lastName") String lastName, Pageable pageable);
-
-	/**
 	 * Checks whether the user exists by email.
 	 *
 	 * @param email received from user service

--- a/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
@@ -201,6 +201,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 	 * @return  the resulting user entity page
 	 * @deprecated Please try to not use this method, as it is much heavier than needed, introduces various bugs and is
 	 *             ultimately slow to debug.
+	 * @since 26.08.2021
 	 */
 	@Deprecated
 	@Query(nativeQuery = true,

--- a/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
@@ -179,10 +179,14 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 	 * @return the resulting user entity page
 	 */
 	@Query(nativeQuery = true,
-			value = " SELECT U.* FROM USERS U"
-					+ "   JOIN DOCTORS D ON U.USER_ID = D.USER_ID"
-					+ "     WHERE UPPER(U.FIRST_NAME) LIKE CONCAT(UPPER(:name), '%') OR "
-					+ "          UPPER(U.LAST_NAME) LIKE CONCAT(UPPER(:name), '%')")
+			value = " SELECT U.* FROM USERS U "
+					+ "     WHERE UPPER(U.FIRST_NAME || ' ' || U.LAST_NAME) LIKE (UPPER(:name) || '%') "
+					+ "        OR UPPER(U.LAST_NAME || ' ' || U.FIRST_NAME) LIKE (UPPER(:name) || '%') "
+					+ "        OR ((coalesce(U.FIRST_NAME, '') <> '') IS TRUE) "
+					+ "           AND (UPPER(U.FIRST_NAME)) LIKE (UPPER(:name) || '%') "
+					+ "        OR ((coalesce(U.LAST_NAME, '') <> '') IS TRUE) "
+					+ "           AND (UPPER(U.LAST_NAME)) LIKE (UPPER(:name) || '%') "
+					+ "   ORDER BY U.FIRST_NAME, U.LAST_NAME ")
 	Page<UserEntity> findDoctorsByName(@Param("name") String name, Pageable pageable);
 
 	/**
@@ -195,7 +199,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 	 * @param lastName received from user service
 	 * @param pageable interface for pagination information received from user service
 	 * @return  the resulting user entity page
+	 * @deprecated Please try to not use this method, as it is much heavier than needed, introduces various bugs and is
+	 *             ultimately slow to debug.
 	 */
+	@Deprecated
 	@Query(nativeQuery = true,
 			value = "SELECT *, "
 					+ "  CASE "

--- a/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
@@ -201,9 +201,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 	 * @return  the resulting user entity page
 	 * @deprecated Please try to not use this method, as it is much heavier than needed, introduces various bugs and is
 	 *             ultimately slow to debug.
-	 * @since 26.08.2021
 	 */
-	@Deprecated
+	@Deprecated(since = "26.08.2021")
 	@Query(nativeQuery = true,
 			value = "SELECT *, "
 					+ "  CASE "

--- a/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/UserRepository.java
@@ -182,10 +182,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 			value = " SELECT U.* FROM USERS U "
 					+ "     WHERE UPPER(U.FIRST_NAME || ' ' || U.LAST_NAME) LIKE (UPPER(:name) || '%') "
 					+ "        OR UPPER(U.LAST_NAME || ' ' || U.FIRST_NAME) LIKE (UPPER(:name) || '%') "
-					+ "        OR ((coalesce(U.FIRST_NAME, '') <> '') IS TRUE) "
-					+ "           AND (UPPER(U.FIRST_NAME)) LIKE (UPPER(:name) || '%') "
-					+ "        OR ((coalesce(U.LAST_NAME, '') <> '') IS TRUE) "
-					+ "           AND (UPPER(U.LAST_NAME)) LIKE (UPPER(:name) || '%') "
 					+ "   ORDER BY U.FIRST_NAME, U.LAST_NAME ")
 	Page<UserEntity> findDoctorsByName(@Param("name") String name, Pageable pageable);
 

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/UserServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import javax.transaction.Transactional;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -109,18 +108,19 @@ public class UserServiceImpl implements UserService {
 			return userRepository.findDoctorsProfiles(pageable).map(userMapper::toUserDTO);
 		}
 
-		List<String> userName = userSearchCriteria.getUserNameList();
+		final String name = userSearchCriteria.getUserName();
 
-		if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS)) && userName.size() == 1) {
-			final String name = userName.get(0);
+		if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS))) {
+			//final String name = userName.get(0);
 			return userRepository.findDoctorsByName(name, pageable).map(userMapper::toUserDTO);
 		}
 
-		if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS)) && userName.size() == 2) {
-			final String firstName = userName.get(0);
-			final String lastName = userName.get(1);
-			return userRepository.findDoctorsByName(firstName, lastName, pageable).map(userMapper::toUserDTO);
-		}
+		// Why do we even need this?
+		//if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS)) && userName.size() == 2) {
+		//	final String firstName = userName.get(0);
+		//	final String lastName = userName.get(1);
+		//	return userRepository.findDoctorsByName(firstName, lastName, pageable).map(userMapper::toUserDTO);
+		//}
 
 		if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_USERNAME))) {
 			return userRepository.findDoctorsProfilesByRegionsIds(

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/UserServiceImpl.java
@@ -111,16 +111,8 @@ public class UserServiceImpl implements UserService {
 		final String name = userSearchCriteria.getUserName();
 
 		if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS))) {
-			//final String name = userName.get(0);
 			return userRepository.findDoctorsByName(name, pageable).map(userMapper::toUserDTO);
 		}
-
-		// Why do we even need this?
-		//if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS)) && userName.size() == 2) {
-		//	final String firstName = userName.get(0);
-		//	final String lastName = userName.get(1);
-		//	return userRepository.findDoctorsByName(firstName, lastName, pageable).map(userMapper::toUserDTO);
-		//}
 
 		if ((validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_USERNAME))) {
 			return userRepository.findDoctorsProfilesByRegionsIds(

--- a/src/main/resources/db/migration/V16__add_uk_ua_collation.sql
+++ b/src/main/resources/db/migration/V16__add_uk_ua_collation.sql
@@ -1,0 +1,1 @@
+CREATE COLLATION "uk-ua-dokazovi-x-icu" ( provider = 'icu', locale = 'uk-ua' );

--- a/src/main/resources/db/migration/V16__add_uk_ua_collation.sql
+++ b/src/main/resources/db/migration/V16__add_uk_ua_collation.sql
@@ -1,1 +1,1 @@
-CREATE COLLATION "uk-ua-dokazovi-x-icu" ( provider = 'icu', locale = 'uk-ua' );
+CREATE COLLATION IF NOT EXISTS "uk-ua-dokazovi-x-icu" ( provider = 'icu', locale = 'uk-ua' );

--- a/src/test/java/com/softserveinc/dokazovi/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/service/impl/UserServiceImplTest.java
@@ -318,7 +318,7 @@ class UserServiceImplTest {
 		Page<UserEntity> userEntityPage = new PageImpl<>(List.of(new UserEntity(), new UserEntity()));
 
 		when(userRepository
-				.findDoctorsByName(anyString(), anyString(), any(Pageable.class)))
+				.findDoctorsByName(anyString(), any(Pageable.class)))
 				.thenReturn(userEntityPage);
 		userService.findAllExperts(userSearchCriteria, pageable);
 		verify(userMapper, times(userEntityPage.getNumberOfElements())).toUserDTO(any(UserEntity.class));
@@ -334,7 +334,7 @@ class UserServiceImplTest {
 		userSearchCriteria.setRegions(set);
 
 		when(userRepository
-				.findDoctorsByName("И", "И", pageable))
+				.findDoctorsByName("И И", pageable))
 				.thenThrow(new EntityNotFoundException("User does not exist"));
 
 		assertThrows(EntityNotFoundException.class, () -> userService


### PR DESCRIPTION
## GitHub Board

[Issue link](https://github.com/ita-social-projects/dokazovi-be/issues/457)

## Code reviewers
- [ ] @teaFunny

## Summary of issue

- [ ] Expert search method in UserService was using an additional unnecessary SQL query, which gave broken results.

## Summary of change

- [ ] Removed the only invokation of the query
- [ ] Marked the query as deprecated, as it's no longer used
- [ ] Updated another query with correct signature to work as intended

## Considerations for future

- [ ] Add an index to increate the LIKE operator execution speed, if needed.