### PR TITLE
Now you can pass the Google Analytics view/profile ID to use it instead of the first available one

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/analytics/GoogleAnalytics.java
+++ b/src/main/java/com/softserveinc/dokazovi/analytics/GoogleAnalytics.java
@@ -54,7 +54,7 @@ public class GoogleAnalytics {
 			String profile = null;
 
 			if (!analyticsProfileId.equals("none")) {
-				profile = getProfileIdByConfig(analytics);
+				profile = getProfileIdByConfig();
 			} else {
 				profile = getFirstProfileId(analytics);
 			}
@@ -98,7 +98,7 @@ public class GoogleAnalytics {
 	}
 
 	// This is a "stub" method, mostly used to cache our profileId in a readable way.
-	private String getProfileIdByConfig(Analytics analytics) throws IOException {
+	private String getProfileIdByConfig() {
 		if (profileId != null) {
 			return profileId;
 		}

--- a/src/main/java/com/softserveinc/dokazovi/analytics/GoogleAnalytics.java
+++ b/src/main/java/com/softserveinc/dokazovi/analytics/GoogleAnalytics.java
@@ -34,6 +34,12 @@ public class GoogleAnalytics {
 
 	@Value("${analytics.creds}")
 	private String googleCredsFromJSON;
+
+	@Value("${analytics.profile:none}")
+	private String analyticsProfileId;
+
+	private String profileId = null;
+
 	private static final String APPLICATION_NAME = "Google Analytics";
 	private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 	private static final Logger logger = LoggerFactory.getLogger(RestAuthenticationEntryPoint.class);
@@ -45,7 +51,13 @@ public class GoogleAnalytics {
 		try {
 			Analytics analytics = initializeAnalytic();
 
-			String profile = getFirstProfileId(analytics);
+			String profile = null;
+
+			if (!analyticsProfileId.equals("none")) {
+				profile = getProfileIdByConfig(analytics);
+			} else {
+				profile = getFirstProfileId(analytics);
+			}
 
 			rows = getResults(analytics, profile, url).getRows();
 
@@ -62,6 +74,9 @@ public class GoogleAnalytics {
 	 * @return An authorized Analytics service object.
 	 */
 	private Analytics initializeAnalytic() throws IOException {
+		if (!analyticsProfileId.equals("none")) {
+			logger.info("We have our Google Analytics profile ID passed directly. Will use that.");
+		}
 
 		HttpTransport httpTransport = null;
 		try {
@@ -82,11 +97,21 @@ public class GoogleAnalytics {
 				.setApplicationName(APPLICATION_NAME).build();
 	}
 
+	// This is a "stub" method, mostly used to cache our profileId in a readable way.
+	private String getProfileIdByConfig(Analytics analytics) throws IOException {
+		if (profileId != null) {
+			return profileId;
+		}
+
+		profileId = analyticsProfileId;
+
+		return profileId;
+	}
+
 	private String getFirstProfileId(Analytics analytics) throws IOException {
-		/**
-		 * Get the first view (profile) ID for the authorized user.
-		 */
-		String profileId = null;
+		if (profileId != null) {
+			return profileId;
+		}
 
 		/**
 		 * Query for the list of all accounts associated with the service account.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ server.port=${PORT:8080}
 endpoints.cors=${ALLOWED_ORIGIN: http://localhost:3000, https://dokazovi-fe.herokuapp.com, http://127.0.0.1:3000,\
                                  http://127.0.0.2:3000, https://dokazovi-frontend.herokuapp.com}
 analytics.creds=${GOOGLE_CREDENTIALS}
+analytics.profile=${ANALYTICS_PROFILE:none}
 
 #-------------------------
 # Database PostgresSQL


### PR DESCRIPTION
## GitHub Board

**Issue link**

[#463 [Analytics] The first account (as said by Google) is chosen to retrieve analytics](https://github.com/ita-social-projects/dokazovi-be/issues/463)

## Code reviewers
- [ ] @teaFunny 

## Summary of issue

- [ ] By default, the first available profile (view) of the first available resource of the first available analytics account is used.
       This can lead to wrong behavior if somebody else adds our API service account to his analytics settings, or we get a new website under the same analytics account.

## Summary of change

- [ ] Now you can pass the profile (view) ID using the `ANALYTICS_PROFILE` environment variable or `analytics.profile` variable in `application.properties`.
