### PR TITLE
Change sending all posts by end point latest mobile to only last 10

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
@@ -274,19 +274,19 @@ public class PostServiceImpl implements PostService {
 	public Page<PostMainPageDTO> findLatestByPostTypesAndOriginsForMobile(Pageable pageable) {
 		PostMainPageDTO expertOptions = PostMainPageDTO.builder()
 				.fieldName("expertOpinion")
-				.postDTOS(postRepository.findLatestByPostTypeExpertOpinion(Pageable.unpaged())
+				.postDTOS(postRepository.findLatestByPostTypeExpertOpinion(PageRequest.of(pageable.getPageNumber(), 10))
 						.map(postMapper::toPostDTO).toList()).build();
 		PostMainPageDTO media = PostMainPageDTO.builder()
 				.fieldName("media")
-				.postDTOS(postRepository.findLatestByPostTypeMedia(Pageable.unpaged())
+				.postDTOS(postRepository.findLatestByPostTypeMedia(PageRequest.of(pageable.getPageNumber(), 10))
 						.map(postMapper::toPostDTO).toList()).build();
 		PostMainPageDTO translation = PostMainPageDTO.builder()
 				.fieldName("translation")
-				.postDTOS(postRepository.findLatestByPostTypeTranslation(Pageable.unpaged())
+				.postDTOS(postRepository.findLatestByPostTypeTranslation(PageRequest.of(pageable.getPageNumber(), 10))
 						.map(postMapper::toPostDTO).toList()).build();
 		PostMainPageDTO video = PostMainPageDTO.builder()
 				.fieldName("video")
-				.postDTOS(postRepository.findLatestByOriginVideo(Pageable.unpaged())
+				.postDTOS(postRepository.findLatestByOriginVideo(PageRequest.of(pageable.getPageNumber(), 10))
 						.map(postMapper::toPostDTO).toList()).build();
 
 		return new PageImpl<>(List.of(expertOptions, media, translation, video));

--- a/src/test/java/com/softserveinc/dokazovi/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/service/impl/PostServiceImplTest.java
@@ -916,7 +916,7 @@ class PostServiceImplTest {
 
 	@Test
 	void findLatestPostsByPostTypesAndOriginForMobile_isOk() {
-		Pageable pageable = Pageable.unpaged();
+		Pageable pageable = PageRequest.of(0, 10);
 		when(postRepository.findLatestByPostTypeMedia(any(Pageable.class)))
 				.thenReturn(postEntityPage);
 		when(postRepository.findLatestByOriginVideo(pageable)).thenReturn(postEntityPage);
@@ -942,7 +942,7 @@ class PostServiceImplTest {
 
 	@Test
 	void findLatestPostsByPostTypesAndOriginForMobile_NotFound() {
-		Pageable pageable = Pageable.unpaged();
+		Pageable pageable = PageRequest.of(0, 10);
 		when(postRepository.findLatestByPostTypeMedia(any(Pageable.class)))
 				.thenReturn(Page.empty());
 		when(postRepository.findLatestByOriginVideo(pageable)).thenReturn(Page.empty());


### PR DESCRIPTION
**Issue link**

[#467 Change sending all posts by end point /latestMobile to only last 10]( )

## Code reviewers
- [ ] @teaFunny 

## Summary of issue

- [ ]  create the method findLatestByPostTypesAndOriginsForMobile in the class PostService
- [ ]  make the implementation of the method specified in the first paragraph in PostServiceImpl

## Summary of change

- [ ]  Changed from Pageable.unpaged() to PageRequest.of(pageable.getPageNumber(), 10) in the PostServiceImpl
- [ ]  Changed test cases from Pageable.unpaged() to PageRequest.of(0, 10);
