### PR TITLE
Issue_534_[Post views counting] For newly created post

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
@@ -306,7 +306,7 @@ public class PostController {
 	@GetMapping(POST_ALL_POSTS + BY_USER_ENDPOINT)
 	@ApiOperation(value = "Get posts, filtered by directions, post types and origins.")
 	public ResponseEntity<Page<PostDTO>> getAllPostsForUserByDirectionsByPostTypesAndByOrigins(
-			@PageableDefault(sort = {"modified_at"}, direction = Sort.Direction.DESC) Pageable pageable,
+			@PageableDefault(sort = {"modifiedAt"}, direction = Sort.Direction.DESC) Pageable pageable,
 			@ApiParam(value = "Multiple comma-separated direction's IDs, e.g. ?directions=1,2,3,4...", type = "string")
 			@RequestParam(required = false) Set<Integer> directions,
 			@ApiParam(value = "Multiple comma-separated post type's IDs, e.g. ?types=1,2,3,4...", type = "string")

--- a/src/main/java/com/softserveinc/dokazovi/dto/post/PostSaveFromUserDTO.java
+++ b/src/main/java/com/softserveinc/dokazovi/dto/post/PostSaveFromUserDTO.java
@@ -62,4 +62,6 @@ public class PostSaveFromUserDTO {
 	private Integer views;
 
 	private Integer realViews;
+
+	private Integer fakeViews;
 }

--- a/src/main/java/com/softserveinc/dokazovi/mapper/PostMapper.java
+++ b/src/main/java/com/softserveinc/dokazovi/mapper/PostMapper.java
@@ -18,6 +18,7 @@ public interface PostMapper {
 
 	@Mapping(target = "views", defaultValue = "0")
 	@Mapping(target = "realViews", defaultValue = "0")
+	@Mapping(target = "fakeViews", defaultValue = "0")
 	PostEntity toPostEntity(PostSaveFromUserDTO postSaveFromUserDTO);
 
 	PostEntity updatePostEntityFromDTO(PostSaveFromUserDTO postSaveFromUserDTO, @MappingTarget PostEntity postEntity);


### PR DESCRIPTION
Adjusted toPostEntity mapping, so that fakeViews for new posts were set to 0 instead of null

develop

## GitHub Board

**Issue link**

[#534 [Post views counting] For newly created post once realViews property is updated, the views count returns null ](https://github.com/ita-social-projects/dokazovi-be/issues/534)

## Code reviewers
- [ ] @teaFunny 

## Summary of issue

- [ ]  toPostEntity mapping returns null for fakeViews of new post


## Summary of change

- [ ]  Adjusted toPostEntity mapping, so that fakeViews for new posts were set to 0 instead of null
