### PR TITLE
issue_543_[Retrieve all-posts & all-posts/{userId}] Returns 500 Error

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
@@ -306,7 +306,7 @@ public class PostController {
 	@GetMapping(POST_ALL_POSTS + BY_USER_ENDPOINT)
 	@ApiOperation(value = "Get posts, filtered by directions, post types and origins.")
 	public ResponseEntity<Page<PostDTO>> getAllPostsForUserByDirectionsByPostTypesAndByOrigins(
-			@PageableDefault(sort = {"modifiedAt"}, direction = Sort.Direction.DESC) Pageable pageable,
+			@PageableDefault Pageable pageable,
 			@ApiParam(value = "Multiple comma-separated direction's IDs, e.g. ?directions=1,2,3,4...", type = "string")
 			@RequestParam(required = false) Set<Integer> directions,
 			@ApiParam(value = "Multiple comma-separated post type's IDs, e.g. ?types=1,2,3,4...", type = "string")

--- a/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
@@ -262,7 +262,7 @@ public class PostController {
 	@GetMapping(POST_ALL_POSTS)
 	@ApiOperation(value = "Get posts, filtered by directions, post types and origins.")
 	public ResponseEntity<Page<PostDTO>> getAllPostsByDirectionsByPostTypesAndByOrigins(
-			@PageableDefault Pageable pageable,
+			@PageableDefault(sort = {"modified_at"}, direction = Sort.Direction.DESC) Pageable pageable,
 			@ApiParam(value = "Multiple comma-separated direction's IDs, e.g. ?directions=1,2,3,4...", type = "string")
 			@RequestParam(required = false) Set<Integer> directions,
 			@ApiParam(value = "Multiple comma-separated post type's IDs, e.g. ?types=1,2,3,4...", type = "string")
@@ -306,7 +306,7 @@ public class PostController {
 	@GetMapping(POST_ALL_POSTS + BY_USER_ENDPOINT)
 	@ApiOperation(value = "Get posts, filtered by directions, post types and origins.")
 	public ResponseEntity<Page<PostDTO>> getAllPostsForUserByDirectionsByPostTypesAndByOrigins(
-			@PageableDefault Pageable pageable,
+			@PageableDefault(sort = {"modified_at"}, direction = Sort.Direction.DESC) Pageable pageable,
 			@ApiParam(value = "Multiple comma-separated direction's IDs, e.g. ?directions=1,2,3,4...", type = "string")
 			@RequestParam(required = false) Set<Integer> directions,
 			@ApiParam(value = "Multiple comma-separated post type's IDs, e.g. ?types=1,2,3,4...", type = "string")

--- a/src/main/java/com/softserveinc/dokazovi/repositories/PostRepository.java
+++ b/src/main/java/com/softserveinc/dokazovi/repositories/PostRepository.java
@@ -205,8 +205,8 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
 			Timestamp startDate, Timestamp endDate, Pageable pageable);
 
 	@Query(nativeQuery = true,
-			value = "SELECT p.*, u.first_name FROM users u, posts p "
-					+ "WHERE p.author_id = u.user_id "
+			value = "SELECT p.* FROM posts p "
+					+ "WHERE p.author_id = :authorId "
 					+ "AND CASE WHEN :typeIds IS NOT NULL "
 					+ "THEN p.type_id IN (:typeIds) "
 					+ "ELSE p.post_id IS NOT NULL "
@@ -225,7 +225,6 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
 					+ "THEN p.status IN (:statuses) "
 					+ "ELSE p.post_id IS NOT NULL "
 					+ "END "
-					+ "AND p.author_id = :authorId "
 					+ "AND p.modified_at between :startDate and :endDate "
 					+ "AND UPPER((p.title) COLLATE \"uk-ua-dokazovi-x-icu\") "
 					+ "LIKE UPPER(('%' || :title || '%') COLLATE \"uk-ua-dokazovi-x-icu\")")
@@ -233,5 +232,8 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
 			Set<Integer> directionIds, Set<String> statuses, Set<Integer> originIds, String title, Integer authorId,
 			Timestamp startDate, Timestamp endDate, Pageable pageable);
 
+	@Query(nativeQuery = true,
+	value = "SELECT p.* FROM posts p "
+			+ "WHERE p.author_id = :authorId")
 	Page<PostEntity> findAllByAuthorId(Integer authorId, Pageable pageable);
 }

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
@@ -109,15 +109,6 @@ public class PostServiceImpl implements PostService {
 			Set<Integer> directionIds, Set<Integer> typeIds, Set<Integer> originIds, Set<Integer> statuses,
 			String title, String author, Integer authorId, LocalDateTime startDate, LocalDateTime endDate,
 			Pageable pageable) {
-
-		if (pageable.getSort().isSorted()) {
-			Sort sort = pageable.getSort().and(Sort.by("modified_at").descending());
-			pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-		} else {
-			Sort sort = Sort.by("modified_at").descending();
-			pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-		}
-
 		boolean isAuthorIdNotSet = authorId == null;
 
 		if (directionIds == null && typeIds == null && originIds == null && statuses == null &&
@@ -130,6 +121,12 @@ public class PostServiceImpl implements PostService {
 						.map(postMapper::toPostDTO);
 			}
 		}
+
+		if (pageable.getSort().isSorted()) {
+			Sort sort = pageable.getSort().and(Sort.by("modified_at").descending());
+			pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+		}
+
 		Optional<LocalDateTime> startDate1 = Optional.ofNullable(startDate);
 		LocalDateTime startTime = startDate1
 				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));

--- a/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
@@ -332,7 +332,7 @@ class PostControllerTest {
 		String title = "";
 		LocalDateTime startDate = null;
 		LocalDateTime endDate = null;
-		Pageable pageable = PageRequest.of(0, 10);
+		Pageable pageable = PageRequest.of(0, 10, Sort.by("modified_at").descending());
 		PostDTO postDTO = PostDTO.builder()
 				.id(1)
 				.build();
@@ -371,7 +371,7 @@ class PostControllerTest {
 		String title = "";
 		LocalDateTime startDate = null;
 		LocalDateTime endDate = null;
-		Pageable pageable = PageRequest.of(0, 10);
+		Pageable pageable = PageRequest.of(0, 10, Sort.by("modified_at").descending());
 		PostDTO postDTO = PostDTO.builder()
 				.id(0)
 				.build();


### PR DESCRIPTION
Adjusted sorting logic & query request

develop

## GitHub Board

**Issue link**

[#543  [Retrieve all-posts & all-posts/{userId}] Returns 500 Error ](https://github.com/ita-social-projects/dokazovi-be/issues/543)

**Story link**

[User story #421 - (Author) The "Materials" («Матеріали») page in the author's personal account](https://github.com/ita-social-projects/dokazovi-requirements/issues/421)
[Bug Report -#518 'Material' page: The ‘Автор’ column header is unclickable in the admin table #518](https://github.com/ita-social-projects/dokazovi-requirements/issues/518)


## Code reviewers
- [ ] @teaFunny 
- [x] @mvalchyshen 

## Summary of issue

- [ ]  Repository method with native query sort by DB table column name, but repository method without native query uses entity name field and fails on the mapping stage.


## Summary of change

- [ ]  Fixed repository method so that it uses native query and sorts data by DB table column name
