### PR TITLE
Fixed return of findAllExperts to correct sorting repository

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/UserServiceImpl.java
@@ -105,7 +105,7 @@ public class UserServiceImpl implements UserService {
 	public Page<UserDTO> findAllExperts(UserSearchCriteria userSearchCriteria, Pageable pageable) {
 
 		if (validateParameters(userSearchCriteria, HAS_NO_DIRECTIONS, HAS_NO_REGIONS, HAS_NO_USERNAME)) {
-			return userRepository.findDoctorsProfiles(pageable).map(userMapper::toUserDTO);
+			return userRepository.findAll(pageable).map(userMapper::toUserDTO);
 		}
 
 		final String name = userSearchCriteria.getUserName();

--- a/src/test/java/com/softserveinc/dokazovi/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/service/impl/UserServiceImplTest.java
@@ -108,7 +108,7 @@ class UserServiceImplTest {
 
 		Page<UserEntity> userEntityPage = Page.empty();
 
-		when(userRepository.findDoctorsProfiles(pageable)).thenReturn(userEntityPage);
+		when(userRepository.findAll(pageable)).thenReturn(userEntityPage);
 
 		assertEquals(userEntityPage, userService.findAllExperts(userSearchCriteria, pageable));
 
@@ -209,7 +209,7 @@ class UserServiceImplTest {
 		userSearchCriteria.setDirections(set);
 		userSearchCriteria.setRegions(set);
 
-		when(userRepository.findDoctorsProfiles(any(Pageable.class)))
+		when(userRepository.findAll(any(Pageable.class)))
 				.thenReturn(userEntityPage);
 
 		userService.findAllExperts(userSearchCriteria, pageable);


### PR DESCRIPTION
Fixed return of findAllExperts to correct sorting repository if there are no regions, directions and username + fixed tests in UserServiceImplTest

develop

User story and test case links:
Bug report: https://github.com/ita-social-projects/dokazovi-requirements/issues/562
Test case: https://github.com/ita-social-projects/dokazovi-requirements/issues/441
User story: https://github.com/ita-social-projects/dokazovi-requirements/issues/301