### PR TITLE
Issue 568 the publications with specified dates are not displayed in the admin table after filling in the ‘дата зміни статусу’ filter

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
@@ -40,7 +40,6 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
+++ b/src/main/java/com/softserveinc/dokazovi/controller/PostController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -278,10 +279,10 @@ public class PostController {
 			@RequestParam(required = false, defaultValue = "") String author,
 			@ApiParam(value = "yyyy-MM-dd'T'HH:mm:ss")
 			@RequestParam(required = false)
-			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 			@ApiParam(value = "yyyy-MM-dd'T'HH:mm:ss")
 			@RequestParam(required = false)
-			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
 		return ResponseEntity
 				.status(HttpStatus.OK)
@@ -322,10 +323,10 @@ public class PostController {
 			@RequestParam(required = false, defaultValue = "") String author,
 			@ApiParam(value = "yyyy-MM-dd'T'HH:mm:ss")
 			@RequestParam(required = false)
-			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 			@ApiParam(value = "yyyy-MM-dd'T'HH:mm:ss")
 			@RequestParam(required = false)
-			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
 			@PathVariable("userId") Integer userId) {
 
 		return ResponseEntity

--- a/src/main/java/com/softserveinc/dokazovi/service/PostService.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/PostService.java
@@ -9,6 +9,7 @@ import com.softserveinc.dokazovi.security.UserPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -27,7 +28,7 @@ public interface PostService {
 
 	Page<PostDTO> findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(
 			Set<Integer> directionIds, Set<Integer> typeIds, Set<Integer> originIds, Set<Integer> statuses,
-			String title, String author, Integer authorId, LocalDateTime startDate, LocalDateTime endDate,
+			String title, String author, Integer authorId, LocalDate startDate, LocalDate endDate,
 			Pageable pageable);
 
 	Page<PostDTO> findPostsByAuthorIdAndDirections(

--- a/src/main/java/com/softserveinc/dokazovi/service/PostService.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/PostService.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Set;
 
 public interface PostService {

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
@@ -17,7 +17,6 @@ import com.softserveinc.dokazovi.repositories.UserRepository;
 import com.softserveinc.dokazovi.security.UserPrincipal;
 import com.softserveinc.dokazovi.service.PostService;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.jni.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
@@ -17,6 +17,7 @@ import com.softserveinc.dokazovi.repositories.UserRepository;
 import com.softserveinc.dokazovi.security.UserPrincipal;
 import com.softserveinc.dokazovi.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.jni.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -107,7 +108,7 @@ public class PostServiceImpl implements PostService {
 	@Override
 	public Page<PostDTO> findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(
 			Set<Integer> directionIds, Set<Integer> typeIds, Set<Integer> originIds, Set<Integer> statuses,
-			String title, String author, Integer authorId, LocalDateTime startDate, LocalDateTime endDate,
+			String title, String author, Integer authorId, LocalDate startDate, LocalDate endDate,
 			Pageable pageable) {
 		boolean isAuthorIdNotSet = authorId == null;
 
@@ -127,14 +128,18 @@ public class PostServiceImpl implements PostService {
 			pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 		}
 
-		Optional<LocalDateTime> startDate1 = Optional.ofNullable(startDate);
-		LocalDateTime startTime = startDate1
-				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp startDateTimestamp = Timestamp.valueOf(startTime);
-		Optional<LocalDateTime> endDate1 = Optional.ofNullable(endDate);
-		LocalDateTime endTime = endDate1
-				.orElse(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
-		Timestamp endDateTimestamp = Timestamp.valueOf(endTime);
+//		Optional<LocalDateTime> startDate1 = Optional.ofNullable(startDate);
+//		LocalDateTime startTime = startDate1
+//				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
+//		Timestamp startDateTimestamp = Timestamp.valueOf(startTime);
+//		Optional<LocalDateTime> endDate1 = Optional.ofNullable(endDate);
+//		LocalDateTime endTime = endDate1
+//				.orElse(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+//		Timestamp endDateTimestamp = Timestamp.valueOf(endTime);
+		LocalDate startLocalDate = Optional.ofNullable(startDate).orElse(LocalDate.EPOCH);
+		LocalDate endLocalDate = Optional.ofNullable(endDate).orElse(LocalDate.now());
+		Timestamp startDateTimestamp = Timestamp.valueOf(startLocalDate.atStartOfDay());
+		Timestamp endDateTimestamp = Timestamp.valueOf(endLocalDate.atStartOfDay());
 		directionIds = validateValues(directionIds);
 		typeIds = validateValues(typeIds);
 		originIds = validateValues(originIds);

--- a/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.Validator;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -330,15 +331,15 @@ class PostControllerTest {
 		Set<Integer> statuses = null;
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Pageable pageable = PageRequest.of(0, 10, Sort.by("modified_at").descending());
 		PostDTO postDTO = PostDTO.builder()
 				.id(1)
 				.build();
 		Page<PostDTO> page = new PageImpl<>(List.of(postDTO));
 		Mockito.when(postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directions, types,
-						origins, statuses, title, author, null, startDate, endDate, pageable))
+						origins, statuses, title, author, null, startLocalDate, endLocalDate, pageable))
 				.thenReturn(page);
 		mockMvc.perform(get(POST + POST_ALL_POSTS + "?directions=1,2&types=1,3&origins=2,3"))
 				.andExpect(status().isOk())
@@ -347,7 +348,7 @@ class PostControllerTest {
 				);
 
 		verify(postService).findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directions, types,
-				origins, statuses, title, author, null, startDate, endDate, pageable);
+				origins, statuses, title, author, null, startLocalDate, endLocalDate, pageable);
 	}
 
 	private Integer getIdFromResponse(String json) {
@@ -369,8 +370,8 @@ class PostControllerTest {
 		Set<Integer> statuses = Set.of(0);
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Pageable pageable = PageRequest.of(0, 10, Sort.by("modified_at").descending());
 		PostDTO postDTO = PostDTO.builder()
 				.id(0)
@@ -378,7 +379,7 @@ class PostControllerTest {
 		Page<PostDTO> page = new PageImpl<>(List.of(postDTO));
 
 		Mockito.when(postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directions, types,
-						origins, statuses, title, author, null, startDate, endDate, pageable))
+						origins, statuses, title, author, null, startLocalDate, endLocalDate, pageable))
 				.thenReturn(page);
 		mockMvc.perform(get(POST + POST_ALL_POSTS +
 						"?directions=-1,1111&types=123,2345&origins=1234,1231&statuses=0"))
@@ -388,7 +389,7 @@ class PostControllerTest {
 				);
 
 		verify(postService).findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directions, types,
-				origins, statuses, title, author, null, startDate, endDate, pageable);
+				origins, statuses, title, author, null, startLocalDate, endLocalDate, pageable);
 	}
 
 	@Test

--- a/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/controller/PostControllerTest.java
@@ -37,7 +37,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.Validator;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/com/softserveinc/dokazovi/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/service/impl/PostServiceImplTest.java
@@ -36,6 +36,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -433,8 +435,8 @@ class PostServiceImplTest {
 		Set<Integer> statuses = null;
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startDate = null;
+		LocalDate endDate = null;
 		Mockito.when(postRepository.findAll(any(Pageable.class))).thenReturn(postEntityPage);
 		postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
 				originsIds, statuses, title, author, null, startDate, endDate, pageable);
@@ -452,8 +454,8 @@ class PostServiceImplTest {
 		Set<Integer> statuses = null;
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startDate = null;
+		LocalDate endDate = null;
 		Mockito.when(postRepository.findAllByAuthorId(any(Integer.class), any(Pageable.class)))
 				.thenReturn(postEntityPage);
 		postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
@@ -500,6 +502,8 @@ class PostServiceImplTest {
 		String title = "";
 		LocalDateTime startDat = null;
 		LocalDateTime endDat = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp startDate = Timestamp.valueOf(Optional.ofNullable(startDat)
 				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN)));
 		Timestamp endDate = Timestamp.valueOf(Optional.ofNullable(endDat)
@@ -508,9 +512,9 @@ class PostServiceImplTest {
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds, directionsIds,
 								statusNames, originsIds, title, author, startDate, endDate, pageable))
-				.thenReturn(postEntityPage);
+						.thenReturn(postEntityPage);
 		postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-				originsIds, statuses, title, author, null, startDat, endDat, pageable);
+				originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable);
 		verify(postMapper, times(postEntityPage.getNumberOfElements())).toPostDTO(any(PostEntity.class));
 	}
 
@@ -528,6 +532,8 @@ class PostServiceImplTest {
 		String title = "";
 		LocalDateTime startDat = null;
 		LocalDateTime endDat = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp startDate = Timestamp.valueOf(Optional.ofNullable(startDat)
 				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN)));
 		Timestamp endDate = Timestamp.valueOf(Optional.ofNullable(endDat)
@@ -538,7 +544,7 @@ class PostServiceImplTest {
 								statusNames, originsIds, title, 1, startDate, endDate, pageable))
 				.thenReturn(postEntityPage);
 		postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-				originsIds, statuses, title, author, 1, startDat, endDat, pageable);
+				originsIds, statuses, title, author, 1, startLocalDate, endLocalDate, pageable);
 		verify(postMapper, times(postEntityPage.getNumberOfElements())).toPostDTO(any(PostEntity.class));
 	}
 
@@ -551,8 +557,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -563,7 +569,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, null, startDate, endDate, pageable)
+								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -576,8 +582,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10, Sort.by("title"));
@@ -589,7 +595,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, null, startDate, endDate, pageable)
+								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -602,8 +608,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -614,7 +620,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, 1, startDate, endDate, pageable)
+								originsIds, statuses, title, author, 1, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -627,8 +633,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -639,7 +645,7 @@ class PostServiceImplTest {
 				.thenThrow(new EntityNotFoundException("Id does not exist"));
 		assertThrows(EntityNotFoundException.class, () -> postService
 				.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds, originsIds,
-						statuses, title, author, null, startDate, endDate, pageable));
+						statuses, title, author, null, startLocalDate, endLocalDate, pageable));
 	}
 
 	@Test
@@ -651,8 +657,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -663,7 +669,7 @@ class PostServiceImplTest {
 				.thenThrow(new EntityNotFoundException("Id does not exist"));
 		assertThrows(EntityNotFoundException.class, () -> postService
 				.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds, originsIds,
-						statuses, title, author, 1, startDate, endDate, pageable));
+						statuses, title, author, 1, startLocalDate, endLocalDate, pageable));
 	}
 
 	@Test
@@ -678,8 +684,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -690,7 +696,7 @@ class PostServiceImplTest {
 								timestampEndDate, pageable))
 				.thenReturn(postEntityPage);
 		postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds, originsIds,
-				statuses, title, author, null, startDate, endDate, pageable);
+				statuses, title, author, null, startLocalDate, endLocalDate, pageable);
 		verify(postMapper, times(postEntityPage.getNumberOfElements())).toPostDTO(any(PostEntity.class));
 	}
 
@@ -706,8 +712,8 @@ class PostServiceImplTest {
 		Set<String> statusNames = Set.of(PostStatus.PUBLISHED.name());
 		String author = "";
 		String title = "";
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -717,7 +723,7 @@ class PostServiceImplTest {
 								timestampEndDate, pageable))
 				.thenReturn(postEntityPage);
 		postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds, originsIds,
-				statuses, title, author, 1, startDate, endDate, pageable);
+				statuses, title, author, 1, startLocalDate, endLocalDate, pageable);
 		verify(postMapper, times(postEntityPage.getNumberOfElements())).toPostDTO(any(PostEntity.class));
 	}
 
@@ -731,8 +737,8 @@ class PostServiceImplTest {
 		String author = "";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -743,7 +749,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, null, startDate, endDate, pageable)
+								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -757,8 +763,8 @@ class PostServiceImplTest {
 		String author = "";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -769,7 +775,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, 1, startDate, endDate, pageable)
+								originsIds, statuses, title, author, 1, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -783,9 +789,9 @@ class PostServiceImplTest {
 		String author = "";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = LocalDateTime.of(LocalDate.of(2019, Month.JANUARY, 1), LocalTime.MIN);
-		LocalDateTime endDate = null;
-		Timestamp timestampStartDate = Timestamp.valueOf(startDate);
+		LocalDate startLocalDate = LocalDate.EPOCH;
+		LocalDate endLocalDate = null;
+		Timestamp timestampStartDate = Timestamp.valueOf(startLocalDate.atStartOfDay());
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
 
@@ -796,7 +802,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, null, startDate, endDate, pageable)
+								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -810,9 +816,9 @@ class PostServiceImplTest {
 		String author = "";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = LocalDateTime.of(LocalDate.of(2019, Month.JANUARY, 1), LocalTime.MIN);
-		LocalDateTime endDate = null;
-		Timestamp timestampStartDate = Timestamp.valueOf(startDate);
+		LocalDate startLocalDate = LocalDate.of(2019, Month.JANUARY, 1);
+		LocalDate endLocalDate = null;
+		Timestamp timestampStartDate = Timestamp.valueOf(startLocalDate.atStartOfDay());
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
@@ -822,7 +828,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, 1, startDate, endDate, pageable)
+								originsIds, statuses, title, author, 1, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -836,8 +842,8 @@ class PostServiceImplTest {
 		String author = "Таржеман";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -848,7 +854,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, null, startDate, endDate, pageable)
+								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -862,8 +868,8 @@ class PostServiceImplTest {
 		String author = "Таржеман";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = null;
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
 		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
 		Pageable pageable = PageRequest.of(0, 10);
@@ -874,7 +880,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, 1, startDate, endDate, pageable)
+								originsIds, statuses, title, author, 1, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 
@@ -913,10 +919,10 @@ class PostServiceImplTest {
 		String author = "";
 		String title = "";
 		Page<PostEntity> postEntityPage = Page.empty();
-		LocalDateTime startDate = null;
-		LocalDateTime endDate = LocalDateTime.of(LocalDate.of(2022, Month.JANUARY, 1), LocalTime.MAX);
+		LocalDate startLocalDate = null;
+		LocalDate endLocalDate = LocalDate.now();
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(endDate);
+		Timestamp timestampEndDate = Timestamp.valueOf(endLocalDate.atStartOfDay());
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
@@ -925,7 +931,7 @@ class PostServiceImplTest {
 				.thenReturn(postEntityPage);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
-								originsIds, statuses, title, author, null, startDate, endDate, pageable)
+								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
 						.getContent().size());
 	}
 

--- a/src/test/java/com/softserveinc/dokazovi/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/softserveinc/dokazovi/service/impl/PostServiceImplTest.java
@@ -36,8 +36,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -64,6 +62,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -507,7 +506,7 @@ class PostServiceImplTest {
 		Timestamp startDate = Timestamp.valueOf(Optional.ofNullable(startDat)
 				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN)));
 		Timestamp endDate = Timestamp.valueOf(Optional.ofNullable(endDat)
-				.orElse(LocalDateTime.of(LocalDate.now(), LocalTime.MAX)));
+				.orElse(LocalDateTime.of(LocalDate.now(), LocalTime.MIN)));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds, directionsIds,
@@ -537,7 +536,7 @@ class PostServiceImplTest {
 		Timestamp startDate = Timestamp.valueOf(Optional.ofNullable(startDat)
 				.orElse(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN)));
 		Timestamp endDate = Timestamp.valueOf(Optional.ofNullable(endDat)
-				.orElse(LocalDateTime.of(LocalDate.now(), LocalTime.MAX)));
+				.orElse(LocalDateTime.of(LocalDate.now(), LocalTime.MIN)));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds, directionsIds,
@@ -560,7 +559,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
@@ -585,7 +584,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10, Sort.by("title"));
 		Pageable pageable1 = PageRequest.of(0, 10, Sort.by("title").and(Sort.by("modified_at").descending()));
 		Mockito.when(postRepository
@@ -611,7 +610,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds,
@@ -636,7 +635,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
@@ -660,7 +659,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds,
@@ -687,7 +686,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 
 		Mockito.when(postRepository
@@ -715,7 +714,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds,
@@ -740,7 +739,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
@@ -766,7 +765,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds,
@@ -792,14 +791,17 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = LocalDate.EPOCH;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(startLocalDate.atStartOfDay());
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 
-		Mockito.when(postRepository
-						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
-								directionsIds, statusNames, originsIds, title, author, timestampStartDate,
-								timestampEndDate, pageable))
-				.thenReturn(postEntityPage);
+//		Mockito.when(postRepository
+//						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
+//								directionsIds, statusNames, originsIds, title, author, timestampStartDate,
+//								timestampEndDate, pageable))
+//				.thenReturn(postEntityPage);
+		doReturn(postEntityPage).when(postRepository).findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
+				directionsIds, statusNames, originsIds, title, author, timestampStartDate,
+				timestampEndDate, pageable);
 		assertEquals(postEntityPage.getContent().size(),
 				postService.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(directionsIds, typesIds,
 								originsIds, statuses, title, author, null, startLocalDate, endLocalDate, pageable)
@@ -819,7 +821,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = LocalDate.of(2019, Month.JANUARY, 1);
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(startLocalDate.atStartOfDay());
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds,
@@ -845,7 +847,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,
@@ -871,7 +873,7 @@ class PostServiceImplTest {
 		LocalDate startLocalDate = null;
 		LocalDate endLocalDate = null;
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByAuthorIdByTypesAndStatusAndDirectionsAndOriginsAndTitle(typesIds,
@@ -896,7 +898,7 @@ class PostServiceImplTest {
 		String title = "Massa eget egestas";
 		Page<PostEntity> postEntityPage = Page.empty();
 		Timestamp timestampStartDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.EPOCH, LocalTime.MIN));
-		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MAX));
+		Timestamp timestampEndDate = Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIN));
 		Pageable pageable = PageRequest.of(0, 10);
 		Mockito.when(postRepository
 						.findAllByTypesAndStatusAndDirectionsAndOriginsAndTitleAndAuthor(typesIds,


### PR DESCRIPTION
Fixed sorting by date in endpoint api/post/all-posts and api/post/all-posts/{userId}. 

**Before:**
![image](https://user-images.githubusercontent.com/95490405/187165525-27302ba9-653e-4ddd-908e-55b05ef82ede.png)


**After:**
![image](https://user-images.githubusercontent.com/95490405/187165793-0dbc4da0-4370-4cc1-af59-7f269801214d.png)

Json file: 
[response_1661763932737.txt](https://github.com/ita-social-projects/dokazovi-be/files/9443254/response_1661763932737.txt)

User story and test case links:
Bug report: https://github.com/ita-social-projects/dokazovi-requirements/issues/525
Test case: https://github.com/ita-social-projects/dokazovi-requirements/issues/376
User story: https://github.com/ita-social-projects/dokazovi-requirements/issues/440