### PR TITLE
Formatting "publishAt" to task #563.

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/dto/post/PostDTO.java
+++ b/src/main/java/com/softserveinc/dokazovi/dto/post/PostDTO.java
@@ -35,7 +35,7 @@ public class PostDTO {
 	private Timestamp createdAt;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd.MM.yyyy")
 	private Timestamp modifiedAt;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd.MM.yyyy")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM.dd.yyyy HH:mm")
 	private Timestamp publishedAt;
 	private Integer importanceOrder;
 	private String importantImageUrl;


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[‘Головна’ page: Date/time of the published cards is not displayed in full format on the material cards #563](https://github.com/ita-social-projects/dokazovi-requirements/issues/563)

**Story link**

[The Top section of the material(mobile) #302](https://github.com/ita-social-projects/dokazovi-requirements/issues/302)


## Code reviewers
- [ ] @teaFunny 
- [ ] @V-Kaidash 

## Summary of issue

- [ ] Formatting of the return from the "publishAt" database to task #563.

## Summary of change

- [ ]  Formatting of the return from the "publishAt" database using the "mm/dd/yyyy hh:mm" pattern.
