### PR TITLE
Date and time formatting of posts returned in json format to task #563.

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/dto/post/PostDTO.java
+++ b/src/main/java/com/softserveinc/dokazovi/dto/post/PostDTO.java
@@ -31,11 +31,11 @@ public class PostDTO {
     private PostTypeDTO type;
     private String status;
     private Set<OriginDTO> origins;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm dd.MM.yyyy")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Timestamp createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd.MM.yyyy")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Timestamp modifiedAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM.dd.yyyy HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Timestamp publishedAt;
     private Integer importanceOrder;
     private String importantImageUrl;


### PR DESCRIPTION
develop

## GitHub Board

**Issue link**

[‘Головна’ page: Date/time of the published cards is not displayed in full format on the material cards #563](https://github.com/ita-social-projects/dokazovi-requirements/issues/563 )

**Story link**

[The Top section of the material(mobile) #302](https://github.com/ita-social-projects/dokazovi-requirements/issues/302 )


## Code reviewers
- [ ] @V-Kaidash 

## Summary of issue

- [ ]  Date and time formatting of posts returned in json format to task #563.


## Summary of change

- [ ]  Formatting the return from the "createdAt" database in Timestamp format (in milliseconds).
- [ ]  Formatting the return from the "modifiedAt" database in Timestamp format (in milliseconds).
- [ ]  Formatting the return from the "publishedAt" database in Timestamp format (in milliseconds).
