### PR TITLE
Issue#549. Post views counting. For updated post.

### DIFF
--- a/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/softserveinc/dokazovi/service/impl/PostServiceImpl.java
@@ -394,7 +394,16 @@ public class PostServiceImpl implements PostService {
         } else {
             PostEntity byId = postRepository.findById(postId)
                     .orElseThrow(EntityNotFoundException::new);
+            Integer fakeViewsById = byId.getFakeViews();
+            Integer realViewsById = byId.getRealViews();
             mappedEntity = postMapper.updatePostEntityFromDTO(postDTO, byId);
+
+            if (postDTO.getFakeViews() == null) {
+                mappedEntity.setFakeViews(fakeViewsById);
+            }
+            if (postDTO.getRealViews() == null) {
+                mappedEntity.setRealViews(realViewsById);
+            }
         }
 
         mappedEntity.setStatus(PostStatus.values()[postDTO.getPostStatus()]);


### PR DESCRIPTION
Adjusted PostEntityFromPostDTO, so that when updating the post, the number of views (realViews and fakeViews) are not written to null.

develop

## GitHub Board

**Issue link**

[[Bug Report] ‘Керування матеріалами’ page: The special symbols and letters are typed into the ‘Змінити кількість переглядів’ field #549 ](https://github.com/ita-social-projects/dokazovi-requirements/issues/549)

**Story link**

[Button "Змінити кількість переглядів" from Action Button Group #382](https://github.com/ita-social-projects/dokazovi-requirements/issues/382)


## Code reviewers
- [ ] @V-Kaidash 

## Summary of issue

- [ ]  toPostEntity mapping write null for fakeViews and realViews of update post.


## Summary of change

- [ ]  Added checks for null. If no data about the number of views comes from the frontend when updating a publication, then the views remain in the database as they were before the update.
